### PR TITLE
django 1.7 doesn't use south

### DIFF
--- a/sanetime/dj.py
+++ b/sanetime/dj.py
@@ -42,7 +42,8 @@ class SaneTimeField(models.BigIntegerField):
         return super(SaneTimeField,self).get_prep_value(value)
 
 
-from south.modelsinspector import add_introspection_rules
-add_introspection_rules([], ["^sanetime\.dj\.SaneTimeField"])
-    
-
+try:
+  from south.modelsinspector import add_introspection_rules
+  add_introspection_rules([], ["^sanetime\.dj\.SaneTimeField"])
+except ImportError:
+  pass


### PR DESCRIPTION
and doesn't seem to need an special introspection rules for custom fields. simply ignoring the import error should be enough to use sanetime in a django 1.7 app without south.

@prior 
